### PR TITLE
[fix] 퀘스트1 완료하는 로직 수정

### DIFF
--- a/Dungeon.cs
+++ b/Dungeon.cs
@@ -84,14 +84,14 @@ namespace TextRPG_project
                     //    }
 
                     //}
-                    if(player.health <= 0)
+                    if (player.health <= 0)
                     {
                         player.health = 0;
                         GameOver(player);
                         break;
                     }
                 }
-                 if(player.health > 0) EnterDungeon(player);
+                if (player.health > 0) EnterDungeon(player);
             }
 
             public void EnterDungeon(Character player)
@@ -133,8 +133,8 @@ namespace TextRPG_project
                 player.PrintSimpleStats();
                 Console.WriteLine();
                 Console.WriteLine("0. 취소");
-                
-                AttackInput(player,1);
+
+                AttackInput(player, 1);
             }
 
             void Skill(Character player)
@@ -145,20 +145,20 @@ namespace TextRPG_project
                 PrintMonsters();
                 player.PrintSimpleStats();
                 Console.WriteLine();
-                
+
                 int attackDamage;
                 Random rand = new Random();
                 Monster monster;
 
                 //if (player.class_type == 1)                     // 전사일 경우
                 //{
-                    Console.WriteLine("1. 알파 스트라이크 - MP 10");
-                    Console.WriteLine("   공격력 * 2 로 하나의 적을 공격합니다.");
-                    Console.WriteLine("2. 더블 스트라이크 - MP 15");
-                    Console.WriteLine("   공격력 * 1.5 로 2명의 적을 랜덤으로 공격합니다.");
-                    Console.WriteLine("0. 취소");
+                Console.WriteLine("1. 알파 스트라이크 - MP 10");
+                Console.WriteLine("   공격력 * 2 로 하나의 적을 공격합니다.");
+                Console.WriteLine("2. 더블 스트라이크 - MP 15");
+                Console.WriteLine("   공격력 * 1.5 로 2명의 적을 랜덤으로 공격합니다.");
+                Console.WriteLine("0. 취소");
                 //}
-                
+
                 //else if (player.class_type == 2)                // 도적일 경우
                 //{
                 //    Console.WriteLine("1.\t알파 스트라이크 - MP 10");
@@ -206,16 +206,16 @@ namespace TextRPG_project
 
                     else
                     {
-                        
-                        if(monsters.Count - DeadCount > 1)
+
+                        if (monsters.Count - DeadCount > 1)
                         {
                             List<Monster> liveMonsters = new List<Monster>();       // 살아있는 monster의 List
                             liveMonsters = monsters.ToList();
-                            for(int i=liveMonsters.Count-1; i>=0; i--)
+                            for (int i = liveMonsters.Count - 1; i >= 0; i--)
                             {
                                 if (liveMonsters[i].IsDead()) liveMonsters.Remove(liveMonsters[i]);     // 죽은 monster를 List에서 제외시킴
                             }
-                            while(liveMonsters.Count > 2)
+                            while (liveMonsters.Count > 2)
                             {
                                 liveMonsters.Remove(liveMonsters[rand.Next(0, liveMonsters.Count)]);    // 2마리가 남을때까지 제외시킴
                             }
@@ -285,8 +285,21 @@ namespace TextRPG_project
                 Console.WriteLine("0. 다음");
                 int input = CheckInput(0, 0);
 
-
-                if (DeadCount == monsters.Count) GameClear(player, this);
+                if (DeadCount == monsters.Count)
+                {
+                    // 퀘스트1(미니언 처치) 수락한 상태고 완료된 상태가 아니면
+                    if (player.acceptQuest[0] && !player.questCleared[0])
+                    {
+                        int deadMinion = 0;
+                        foreach (Monster mon in monsters)
+                        {
+                            if (mon.level == 2)
+                                deadMinion++;
+                        }
+                        player.questNumber[0] += deadMinion; // 처치한 미니언의 수 더하기
+                    }
+                    GameClear(player, this);
+                }
                 else EnemyPhase(player);
             }
 

--- a/Quest.cs
+++ b/Quest.cs
@@ -132,7 +132,7 @@ namespace TextRPG_project
                 }
                 else    // 퀘스트 이미 수락한 상태
                 {
-                    if (player.questNumber[1] < questRequired)  //퀘스트 완료 조건 못채움
+                    if (player.questNumber[questNum] < questRequired)  //퀘스트 완료 조건 못채움
                     {
                         Console.WriteLine("1. 확인");
                         int input = CheckInput(1, 1);


### PR DESCRIPTION
GameClear() 호출 전 죽은 몬스터 중 level이 2인 몬스터 마리수만큼 카운트하는 로직 추가